### PR TITLE
Add test for dash display in GameLoop

### DIFF
--- a/src/test/java/org/GameLoopTest.java
+++ b/src/test/java/org/GameLoopTest.java
@@ -1,0 +1,37 @@
+package org;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.*;
+
+public class GameLoopTest {
+    @Test
+    public void testDisplayMatchesWordLengthAfterFirstGuess() {
+        String word = "java";
+        ByteArrayInputStream in = new ByteArrayInputStream("x\n".getBytes());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        InputStream originalIn = System.in;
+        PrintStream originalOut = System.out;
+        try {
+            System.setIn(in);
+            System.setOut(new PrintStream(out));
+            GameLoop loop = new GameLoop(word, 1);
+            loop.start();
+        } finally {
+            System.setIn(originalIn);
+            System.setOut(originalOut);
+        }
+        String output = out.toString();
+        String currentWordLine = null;
+        for (String line : output.split(System.lineSeparator())) {
+            if (line.startsWith("Current word:")) {
+                currentWordLine = line;
+                break;
+            }
+        }
+        assertNotNull("Should print current word line", currentWordLine);
+        long dashCount = currentWordLine.chars().filter(ch -> ch == '-').count();
+        assertEquals(word.length(), dashCount);
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit test for GameLoop verifying dash display matches word length

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68922ec913e88329b4f1576e4dcfc77a