### PR TITLE
fix display length initialization

### DIFF
--- a/src/main/java/org/GameLoop.java
+++ b/src/main/java/org/GameLoop.java
@@ -14,7 +14,7 @@ public class GameLoop {
 
     public void start() {
         int attempts = maxAttempts;
-        StringBuilder display = new StringBuilder("----------");
+        StringBuilder display = new StringBuilder("-".repeat(word.length()));
         Set<Character> guessedLetters = new HashSet<>();
         Scanner scanner = new Scanner(System.in);
 


### PR DESCRIPTION
## Summary
- initialize hangman display with dashes matching the hidden word's length

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68922eb2ed548329bc427c76d55cdb83